### PR TITLE
#204: Fix composer deps:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         "php": ">=7.4",
         "ext-json": "*",
         "ext-pdo": "*",
-        "illuminate/container": ">=5.8",
+        "illuminate/container": ">=v9.11.0",
         "lcobucci/jwt": "^3.2",
         "league/fractal": "~0.14",
         "nwidart/laravel-modules": ">=3.1",
         "predis/predis": "^1.1",
-        "raml-org/raml-php-parser": "^4.1"
+        "raml-org/raml-php-parser": "^v4.8.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,10 +48,11 @@
         }
     },
     "require-dev": {
+        "roave/security-advisories": "dev-latest",
         "codeception/codeception": ">=2.4",
         "darkaonline/l5-swagger": ">=5.8",
         "fzaninotto/faker": "^1.7",
-        "laravel/framework": ">=5.8",
+        "laravel/framework": ">=v9.10.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": ">=6.5"
     },


### PR DESCRIPTION
"illuminate/container": ">=v9.11.0",
"raml-org/raml-php-parser": "^v4.8.0"

to support Laravel > 9.0.0